### PR TITLE
devcontainer

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,2 @@
+.git
+crafty/.git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json.
+// See also https://code.visualstudio.com/docs/devcontainers/create-dev-container#_dockerfile.
+{
+	"name": "node",
+	"build": {
+		"dockerfile": "../Containerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [5173],
+
+	"postStartCommand": "yarn build-submodule",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [ // Automatically install these extensions in the container
+				"antfu.vite"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"antfu.vite"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"vite.buildCommand": "yarn run build",
+	"vite.devCommand": "yarn run dev",
+	"vite.port": 5173
+}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,6 @@
+FROM docker.io/library/node:18
+
+WORKDIR /root
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --quiet
+ENV PATH=/root/.cargo/bin:$PATH
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build-submodule": "bash -c \"cd crafty && . build-web.sh\"",
+    "build-submodule": "bash -c \"cd crafty && ./build-web.sh\"",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
+  server: {
+    host: true,
+    strictPort: true,
+  },
+  plugins: [react()],
 })


### PR DESCRIPTION
this changes the vite config to listen on all interfaces (0.0.0.0) instead of localhost so that it can be exposed from outside the container

this adds a `Containerfile` and recommendeds the antfu.vite vscode extension so you can develop (on your host/outside a container) and build/run inside the container with
```
podman build . -t craftingway
podman run --rm -it -v `pwd`:/usr/src craftingway bash
# yarn run build-submodule
# yarn install
# yarn run dev
```
this also adds workspace overrides for antfu.vite to make it use yarn instead of npm (workspace settings override both user and remote/container settings)

this adds a `.devcontainer/` which builds that container for you, runs the `build-submodule` command, and installs the antfu.vite extension which prompts you to install yarn packages and then automatically runs the vite server