### PR TITLE
use prettier vsc extension to format js,jsx,ts,tsx

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typecriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
+}


### PR DESCRIPTION
set workspace-level overrides for formatters (this overrides both devcontainer-level and user-level settings, so the downside is there's pretty much no way for a user to unset this without generating a diff if they want to use a different formatter)