### PR TITLE
(de)serialize player, food, potion, and recipe to URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/sortable": "^7.0.1",
     "@fontsource/fira-mono": "^4.5.10",
+    "@jsonurl/jsonurl": "^1.1.7",
     "@radix-ui/react-tooltip": "^1.0.5",
     "clsx": "^1.2.1",
     "crafty": "link:crafty/web/pkg",

--- a/src/lib/recipe-state.ts
+++ b/src/lib/recipe-state.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable } from "mobx";
+import { makeAutoObservable, runInAction } from "mobx";
 import type { Recipe } from "crafty";
 import { unpack } from "msgpackr/unpack";
 
@@ -50,6 +50,7 @@ class _RecipeState {
     const response = await fetch("recipes.msgpack");
     const rawRecipeData: RawRecipeData[] = unpack(new Uint8Array(await response.arrayBuffer()));
     this.recipes = rawRecipeData.map((raw) => ({ ...raw, jobs: new Set(raw.jobs) }));
+    runInAction(() => (this.loaded = true));
   }
 
   get recipe() {

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,75 @@
+import JsonURL from "@jsonurl/jsonurl";
+import type { Player } from "crafty";
+import { autorun, when } from "mobx";
+
+import { FOOD_VARIANTS, POTION_VARIANTS } from "./consumables";
+import { Job } from "./jobs";
+import { PlayerState } from "./player-state";
+import { RecipeState } from "./recipe-state";
+
+interface URLData {
+  v: number;
+  job: Job;
+  player: Player;
+  food: string | undefined;
+  potion: string | undefined;
+  recipe: string | undefined;
+}
+
+const urlVersion = 1;
+const jsonURLOptions = { AQF: true, noEmptyComposite: true };
+
+export function setupURL() {
+  // once recipes are loaded, run this function once
+  when(
+    () => RecipeState.loaded,
+    () => {
+      deserializeURL(); // deserialize the URL into state
+      autorun(updateURL); // whenever state changes, serialize into the URL
+    }
+  );
+}
+
+function deserializeURL() {
+  if (location.search.substring(0, 3) !== "?c=") return;
+  const data: URLData = JsonURL.parse(location.search.substring(3), jsonURLOptions);
+  if (data.v != urlVersion) {
+    console.debug("ignoring old url data version", data.v);
+    return;
+  }
+
+  PlayerState.job = data.job;
+  PlayerState.setConfig(data.player);
+
+  if (data.food) {
+    const food = FOOD_VARIANTS.find((f) => f.name === data.food);
+    if (food) PlayerState.setConfig({ food });
+  }
+  if (data.potion) {
+    const potion = POTION_VARIANTS.find((p) => p.name === data.potion);
+    if (potion) PlayerState.setConfig({ potion });
+  }
+  if (data.recipe) {
+    const recipe = RecipeState.recipes.find((r) => r.name === data.recipe);
+    if (recipe) RecipeState.recipe = recipe;
+  }
+}
+
+function updateURL() {
+  const player = PlayerState.config;
+  const data: URLData = {
+    v: urlVersion,
+    job: PlayerState.job,
+    player: {
+      job_level: player.job_level,
+      craftsmanship: player.craftsmanship,
+      control: player.control,
+      cp: player.cp,
+    },
+    food: player.food?.name,
+    potion: player.potion?.name,
+    recipe: RecipeState.recipe?.name,
+  };
+  const encoded = JsonURL.stringify(data, jsonURLOptions);
+  history.replaceState({}, "", "/?c=" + encoded);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import { configure } from "mobx";
 
 import App from "./components/App";
+import { setupURL } from "./lib/url";
 
 configure({
   enforceActions: "observed",
@@ -17,3 +18,5 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <App />
   </React.StrictMode>
 );
+
+setupURL();

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@jsonurl/jsonurl@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@jsonurl/jsonurl/-/jsonurl-1.1.7.tgz#aab830c95fa402f09512ed1b5128be2c60c67a21"
+  integrity sha512-H3aKlfSjVoUhhNRO+2HDtVNq8UT0TV8kyAgJ29bETLdjU6Xz3s1PMzbRkfcAdwuwzHjiisabHpJoP8p+hju6bA==
+
 "@lukeed/ms@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@lukeed/ms/-/ms-2.0.1.tgz#3c2bbc258affd9cc0e0cc7828477383c73afa6ee"


### PR DESCRIPTION
urls look like `/?c=(job:ALC,player:(job_level:50,craftsmanship:1,control:2,cp:183),food:Jhinga+Biryani,potion:Cunning+Draught,recipe:Orphanage+Donation+Component)`

should we add a version to these urls? otherwise, if we add a new field (like simulator settings), it'll try to grab them from old urls and explode unless we're careful about backwards compatibility